### PR TITLE
fix EONET missing file problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bundle": "browserify demo.js --transform glslify | uglifyjs -cm > bundle.js"
   },
   "browser": {
-    "./load.js": "load-browser.js"
+    "./load.js": "./load-browser.js"
   },
   "author": {
     "name": "Hugh Kennedy",


### PR DESCRIPTION
when you `npm install` and try to use this from a different module (in the browser) you get an error since it seems to be looking for an absolute path
